### PR TITLE
Adding more variables to typography  baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,25 @@ This is a fairly unopinionated approach to making sure that the text has a decen
 ## Usage
 While this is relatively unopinionated, there are a few "opinions" to consider:
 
-* `em` for for `font-size`
-* a unitless `line-height`
+* [`em` for for `font-size`](https://css-tricks.com/rems-ems/)
+* [a unitless `line-height`](https://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/)
 * `rem` for left/right spacing
-* text-spacing based on the golden ratio (.618 / 1.618)
+* [text-spacing based on the golden ratio ](https://pearsonified.com/golden-ratio-typography-intro/)(.618 / 1.618)
 
 ### Fitting it into a CSS architecture
-This would come after a reset / normalize and before you set baseline styles for forms or tables. If you're a fan of [ITCSS](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/), this is in the Elements layer.
+This would come after a reset / [normalize](https://necolas.github.io/normalize.css/) and before you set baseline styles for forms or tables. If you're a fan of [ITCSS](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/), this is in the Elements layer.
+
+If you were to load this into a [CSS Layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer), you would want it to come very early so that you could over ride it. 
+
+Whereever you place it, place it _early_ in the cascade so that other things can use and/or  re-declare the variables. 
 
 ### Modifying without Swearing or Heavy Drinking
 One of the really annoying things about other CSS frameworks (cough cough <small>Bootstrap</small>) is that you mostly have to write new CSS to overwrite the existing styles. Often that means raising specificity, which is really stinking annoying. This is designed to avoid that by using [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
 
 
-The typography baseline sets all of the CSS variables on the `:root`. As CSS variables are subject to the cascade, you can override _any_ variable at any time by changing its value on the relevant selector. You can import this into your current CSS setup, and overwrite all the variables by setting new ones on the `html` element. 
+The typography baseline sets all of the CSS variables on the `:root`. As CSS variables are subject to the cascade, you can override _any_ variable at any time by changing its value &mdash; on the same selector *or* a more specific one.
+
+You can import this into your current CSS setup, and overwrite all the variables by setting new ones on the `html` element. 
 
 So if you want the `--baseLinkColor` to be different, you can write the following in your own stylesheet:
 
@@ -62,7 +68,7 @@ html {
 }
 ```
 
-No raising specificity. Just changing a variable. 
+**No raising specificity. Just changing a variable.**
 
 If you want to theme a special area of the site, or even a particular widget, it's just:
 
@@ -85,8 +91,10 @@ Colors are derivitives of a base value of 55. All of the neutral colors are mult
 ```
 Color-naming convention follows a pattern established [here](https://codepen.io/paceaux/pen/XdxQza). A big huge and heavy thanks to Sarah Braumiller for suggesting that convention years ago. 
 
+[The great big idea](https://blog.frankmtaylor.com/2021/10/21/a-small-guide-for-naming-stuff-in-front-end-code/#css-pre-processor-naming-scss-sass-less-stylus) is that these color name tells you a meaningful aspect of the value, not the value itself. That way it feels safer changing it. 
+
 #### Colors
-All of the colors variables are abstractions from the color palette. This is so you can change these colors without having to touch your neutral palette. 
+All of the color variables are abstractions from the color palette. This is so you can change these colors without having to touch your neutral palette. 
 
 ```
     --baseTextColor: var(--colorNeutralDarker);
@@ -131,6 +139,10 @@ You may also notice that title sizes overlap with base text sizes. This is inten
     --smallerTitleSize: var(--biggerTextSize);
     --smallestTitleSize: var(--bigTextSize);
 ```
+
+You may notice that all of the font-sizes are in `em`. This is _intentional_ so that your headlines can scale easily relative to the font-size of their containers. That means **you should be careful about how many times you change `font-size`**. 
+
+If you think you'll be changing `font-size` _a lot_, you may want to set these in `rem` instead, to avoid FOUC (Flash Of Unstyled Content). 
 
 #### Spacing
 Spacing is done with the golden ratio (.618 / 1.618)
@@ -205,7 +217,7 @@ One of the very few strong opinions in this baseline is the look and feel of a b
 The CSS follows the guidelines established [here](https://gist.github.com/paceaux/f31e278613ab29b74a412a7eb5046422).
 
 ### Naming Conventions
-CSS Variable names follow a convention established [here](https://gist.github.com/paceaux/8638765e747f5bd6387b721cde99e066#sassscssstylus-naming).
+CSS Variable names follow a convention established [here](https://blog.frankmtaylor.com/2021/10/21/a-small-guide-for-naming-stuff-in-front-end-code/).
 
 
 [license-image]: http://img.shields.io/npm/l/typography-baseline.css.svg

--- a/README.md
+++ b/README.md
@@ -50,7 +50,18 @@ This would come after a reset / [normalize](https://necolas.github.io/normalize.
 
 If you were to load this into a [CSS Layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer), you would want it to come very early so that you could over ride it. 
 
-Whereever you place it, place it _early_ in the cascade so that other things can use and/or  re-declare the variables. 
+Wherever you place it, place it _early_ in the cascade so that other things can use and/or  re-declare the variables. 
+
+#### Using it in a project
+1. Add the baseline
+    - import into your project with NPM  `@import typography-baseline.css`
+    - <kbd>copy</kbd> + <kbd>paste</kbd> this project's `baseline.css`
+2. Add your own `typography.css` file that comes after the baseline, but before you style anything else.
+3. Add something like `html {}` or `body {}`.
+4. Modify the variables _in those rulesets_.
+5. Then add your own element styles. 
+
+**Don't modify the typography-baseline directly. Modify the variables it sets with new rulesets.**
 
 ### Modifying without Swearing or Heavy Drinking
 One of the really annoying things about other CSS frameworks (cough cough <small>Bootstrap</small>) is that you mostly have to write new CSS to overwrite the existing styles. Often that means raising specificity, which is really stinking annoying. This is designed to avoid that by using [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
@@ -80,7 +91,7 @@ If you want to theme a special area of the site, or even a particular widget, it
 
 
 #### Color Palette
-Colors are derivitives of a base value of 55. All of the neutral colors are multipliers of rgb(55,55,55). Even the non-neutral colors are close-ish to that. 
+Colors are derivatives of a base value of 55. All of the neutral colors are multipliers of rgb(55,55,55). Even the non-neutral colors are close-ish to that. 
 
 ```
     --colorNeutralDarker: rgb(55,55,55);                  /* base       */
@@ -185,6 +196,8 @@ You have three font weights to choose from.
     --heavyFontWeight: 500;
     --heavierFontWeight: 600
  ```
+
+Keep in mind that [the browser will synthesize the font weights unless font-families with those weights are provided to the browser](https://w3c.github.io/csswg-drafts/css-fonts-4/#missing-weights) &mdash; unless you are using a [variable font ](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#variable_fonts). Add more font-weights carefully. 
 
 ##### Font Styles
 You have three font styles to use. These are called `fontVoice` because it's important for you to imagine how a person might read the text _out loud_. If you think someone might enunciate or pronounce it differently, that's "italic" (what you might use for `<em>` or `<i>`). The browser will actually look for an italic font. 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,71 @@ You may also notice that title sizes overlap with base text sizes. This is inten
     --smallestTitleSize: var(--bigTextSize);
 ```
 
-#### Font families
+#### Spacing
+Spacing is done with the golden ratio (.618 / 1.618)
+`rem` is used for horizontal spacing so that text remains aligned, regardless of size. `em` is used for vertical spacing so that bigger text gets more room to breathe. 
+You have two spacings to start with. 
+
+```
+    --bigSpacingHorizontal: 1.618rem;
+    --baseSpacingHorizontal: .618rem;
+
+    --bigSpacingVertical: 1.618em;
+    --baseSpacingVertical: .618em;
+```
+
+#### Font Modifications
+
+##### Font families
 You have three font families to choose from. `--baseFontFamily` is applied to the html element. 
 
 ```
     --baseFontFamily: Georgia, 'Times New Roman', serif;
     --titleFontFamily: Helvetica, Arial, sans-serif;
     --codeFontFamily: monospace;
+```
+
+##### Font Weights
+You have three font weights to choose from.
+
+```
+    --lightestFontWeight: 100;
+    --baseFontWeight: 400;
+    --heaviestFontWeight: 700;
+```
+
+ Even though a browser technically has nine font-weights, you can follow the pattern of adding "er" or "est" to add another four. Just make sure you've added those typefaces!
+
+ ```
+    --lightFontWeight: 300;
+    --lighterFontWeight: 200;
+    --heavyFontWeight: 500;
+    --heavierFontWeight: 600
+ ```
+
+##### Font Styles
+You have three font styles to use. These are called `fontVoice` because it's important for you to imagine how a person might read the text _out loud_. If you think someone might enunciate or pronounce it differently, that's "italic" (what you might use for `<em>` or `<i>`). The browser will actually look for an italic font. 
+
+If you just want to show slanted text, that's "oblique". The browser is just going to angle the font. 
+
+```
+    --shiftedFontVoice: oblique 15deg;
+    --baseFontVoice: normal;
+    --alternateFontVoice: italic;
+```
+
+#### Quote Styles
+One of the very few strong opinions in this baseline is the look and feel of a blockquote. However, you can set the  quotes that come before and after the `<blockquote>` and `<q>` elements. This is useful for internationalization; you have one place to make sure all quote symbols are updated!
+
+```
+    --baseTextQuotes: "\201C""\201D""\2018""\2019"; 
+```
+
+`<blockquote>` and `<samp>` both share a thick left "quote border":
+
+```
+    --baseQuoteBorder: 10px solid var(--colorNeutralLighter);
+    --smallQuoteBorder: 5px solid var(--colorNeutralLight);
 ```
 
 ## Conventions and Standards

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ You have three font weights to choose from.
     --heaviestFontWeight: 700;
 ```
 
- Even though a browser technically has nine font-weights, you can follow the pattern of adding "er" or "est" to add another four. Just make sure you've added those typefaces!
+ While the browser technically has nine font-weights, you're only able to add another four (for a total of seven) by following the pattern of adding "er" or "est". If you *really* need nine font-weights, consider naming the ones at the heavy end `--ultraHeavy` and `--ultraHeaviest`. 
+ 
+ *Just make sure you've added those typefaces!*
 
  ```
     --lightFontWeight: 300;
@@ -197,7 +199,7 @@ You have three font weights to choose from.
     --heavierFontWeight: 600
  ```
 
-Keep in mind that [the browser will synthesize the font weights unless font-families with those weights are provided to the browser](https://w3c.github.io/csswg-drafts/css-fonts-4/#missing-weights) &mdash; unless you are using a [variable font ](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#variable_fonts). Add more font-weights carefully. 
+If you add more font-weights, remember that [the browser will synthesize the font weights unless proper font-families with those weights are provided](https://w3c.github.io/csswg-drafts/css-fonts-4/#missing-weights)&mdash; unless you are using a [variable font ](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#variable_fonts). **Add more font-weights carefully**. 
 
 ##### Font Styles
 You have three font styles to use. These are called `fontVoice` because it's important for you to imagine how a person might read the text _out loud_. If you think someone might enunciate or pronounce it differently, that's "italic" (what you might use for `<em>` or `<i>`). The browser will actually look for an italic font. 

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -263,12 +263,16 @@ blockquote {
     padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
 }
 
-blockquote::before {
+blockquote::before,
+blockquote::after {
     color: var(--colorNeutralLight);
     font-size: 4em;
     line-height: 0.1em;
-    margin-right: 0.25em;
-    vertical-align: -0.4em;
+    vertical-align: -0.5em;
+}
+
+blockquote::before {
+    margin-right: var(--baseSpacingHorizontal);
 }
 
 blockquote::after {

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -26,6 +26,7 @@
     --baseTextLineColor: var(--baseTextColor);
     --alertTextLineColor: rgb(255, 0, 0);
 
+    --baseQuoteBackgroundColor: 165, 165, 165, ;
 /*===== 
     #LineHeight 
 =====*/
@@ -237,7 +238,7 @@ p {
     https://css-tricks.com/snippets/css/simple-and-nice-blockquote-styling/
 */
 blockquote {
-    background: rgba(165, 165, 165, .15);
+    background: rgba(var(--baseQuoteBackgroundColor) 0.15);
     border-left: 10px solid var(--colorNeutralLighter);
     margin: var(--bigSpacingVertical) var(--baseSpacingHorizontal);
     padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
@@ -309,7 +310,7 @@ del {
 
 ins,
 del {
-    background-color: rgba(220, 220, 220, .25);
+    background-color: rgba(220, 220, 220, 0.25);
 }
 
 ins {
@@ -323,25 +324,25 @@ u {
 }
 
 /*
-mark and selection should be different, so user knows which one they've selected.
-
-mark and selections:
-  saturation: 44%
-  lightness: 75%
-Hue is different
+mark and selection should be different so user knows which one they've selected.
 */
 
+/* hue: 120, saturation: 44%, lightness: 75%  */
 mark {
-    background-color: rgba(165, 220, 165, .9);
+    background-color: rgba(165, 220, 165, 0.9);
 }
 
+/*hue: 180, saturation: 44%, lightness: 75%*/
 ::selection {
-    background-color: rgba(165, 220, 220, .9);
+    background-color: rgba(165, 220, 220, 0.9);
 }
 
-/* Because mark and selection have same saturation, brightenss, mark won't easily stand out if it's selected */
+/* Because mark and selection have same saturation and brightenss, a selected <mark> won't stand out
+    A hue between 120 and 180 seems to stand out the best in all colorblind tests, too
+    hue: 150, saturation: 44%, lightness: 65%
+ */
 mark::selection {
-    background-color: rgba(165, 220, 110, .9);
+    background-color: rgba(126, 205, 166, 0.9);
 }
 
 /* dfn and dt both do the same thing: denote a term to be defined */
@@ -376,7 +377,7 @@ data {
 kbd,
 samp,
 data {
-    background-color: rgba(165, 165, 165, .2);
+    background-color: rgba(var(--baseQuoteBackgroundColor) 0.2);
 }
 
 kbd {

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -75,6 +75,18 @@
     --baseFontFamily: Georgia, 'Times New Roman', serif;
     --titleFontFamily: Helvetica, Arial, sans-serif;
     --codeFontFamily: monospace;
+
+/*===== 
+    #Font #Weight
+    though font-weight ranges from 100 - 900, "normal" is 400 and the ends
+         are a difference of 300 .
+    So the "est" weights are the extremes, with room to add 
+        light, lighter, heavy, heavier. 
+    Recommend adding "ultra" if the weight is > 700
+=====*/
+    --lightestFontWeight: 100;
+    --baseFontWeight: 400;
+    --heaviestFontWeight: 700; 
 }
 
 html {
@@ -116,7 +128,7 @@ h4,
 h5,
 h6 {
     font-family: var(--titleFontFamily);
-    font-weight: bold;
+    font-weight: var(--heaviestFontWeight);
     line-height: var(--smallLineHeight);
     margin-bottom: calc(1.618vmin - 1vmax + .35em); /* increases margin as screen width gets smaller */
 }
@@ -157,7 +169,7 @@ dl {
 }
 
 li {
-    text-indent: -.9em;
+    text-indent: -.9em; /*this brings the left text aligned with the text of a <dd> element*/
     line-height: var(--baseLineHeight);
     padding: 0;
     margin: 0 0 0 var(--baseSpacingHorizontal);
@@ -232,7 +244,7 @@ cite {
 
 strong,
 b {
-    font-weight: 700;
+    font-weight: var(--heaviestFontWeight);
 }
 
 cite {
@@ -314,7 +326,7 @@ mark::selection {
 dfn,
 dt {
     font-style: oblique;
-    font-weight: 700;
+    font-weight: var(--heaviestFontWeight);
     text-transform: capitalize;
 }
 
@@ -487,7 +499,7 @@ th, td {
 
 th {
     font-family: var(--titleFontFamily);
-    font-weight: bold;
+    font-weight: var(--heaviestFontWeight);
     font-size: var(--smallTitleSize); /*treat th in a body as h4*/
 }
 

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -101,9 +101,14 @@
     --alternateFontVoice: italic;
 
 /*===== 
-    #font #quotes
+    #font #quotes #border
+    These are the default quotes for English. Change these quotes-as needed for other languages
+    "secondary" quotes are nested quotes. e.g. <blockquote><blockquote>
+    the CSS properties 'open-quote', 'close-quote' will use the primary open and primary close quotes listed here
 =====*/
     --baseTextQuotes: "\201C""\201D""\2018""\2019"; /*Primary open, primary close, secondary open, secondary close*/
+    --baseQuoteBorder: 10px solid var(--colorNeutralLighter);
+    --smallQuoteBorder: 5px solid var(--colorNeutralLight);
 
 /*===== 
     #font #text #interactions
@@ -253,7 +258,7 @@ q::before {
 */
 blockquote {
     background: rgba(var(--baseQuoteBackgroundColor) 0.15);
-    border-left: 10px solid var(--colorNeutralLighter);
+    border-left: var(--baseQuoteBorder);
     margin: var(--bigSpacingVertical) var(--baseSpacingHorizontal);
     padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
 }
@@ -418,7 +423,7 @@ data {
 }
 
 samp {
-    border-left: 5px solid var(--baseInlineBorderColor);
+    border-left: var(--smallQuoteBorder);
 }
 
 data {

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -28,6 +28,9 @@
     --baseLinkColorHover: var(--colorCoolDarker);
     --baseInlineBorderColor: var(--colorNeutralLight);
 
+    --baseTextLineColor: var(--baseTextColor);
+    --alertTextLineColor: rgb(255, 0, 0);
+
 /*===== 
     #LineHeight 
 =====*/
@@ -98,6 +101,17 @@
     --shiftedFontVoice: oblique 15deg;
     --baseFontVoice: normal;
     --alternateFontVoice: italic;
+
+/*===== 
+    #font #text #interactions
+    Interactions could/should include
+        idle: not being used, but an indicator that it can be
+        interest: a user has shown desire to interact (e.g. hover or focus)
+        active: a user is currently interacting
+=====*/
+    --idleTextLineStyle: dotted;
+    --activeTextLineStyle: solid;
+    --idleTextDecoration: var(--idleTextLineStyle) underline 2px;
 }
 
 html {
@@ -263,10 +277,6 @@ cite {
     text-align: right;
 }
 
-u {
-    text-decoration: dotted underline red 1px;
-}
-
 small,
 sub,
 sup {
@@ -309,6 +319,11 @@ ins {
     text-decoration: none;
 }
 
+/* U is for misspelled words. Invite user to make a correction */
+u {
+    text-decoration: var(--idleTextDecoration);
+    text-decoration-color: var(--alertTextLineColor);
+}
 
 /*
 mark and selection should be different, so user knows which one they've selected.
@@ -340,7 +355,15 @@ dt {
     text-transform: capitalize;
 }
 
+abbr {
+    text-transform: uppercase;
+    text-decoration: none;
+}
 
+/* an abbreviation with a title should invite a user to hover over it*/
+abbr[title] {
+    text-decoration: var(--idleTextDecoration);
+}
 /*=====
 #Content-flow #Code
 =====*/
@@ -374,8 +397,8 @@ data {
 
 var,
 data {
+    font-style: var(--alternateFontVoice);
 }
-font-style: var(--alternateFontVoice);
 
 samp {
     border-left: 5px solid var(--baseInlineBorderColor);
@@ -470,7 +493,7 @@ rtc > bdo {
 a {
     color: var(--baseLinkColor);
     text-decoration: none;
-    border-bottom: 1px dotted transparent;
+    border-bottom: 1px var(--idleTextLineStyle) transparent;
     transition: all .3s ease-in-out;
 }
 
@@ -482,7 +505,7 @@ a:focus {
 }
 
 a:active {
-    border-style: solid;
+    border-style: var(--activeTextLineStyle);
 }
 
 

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -1,8 +1,3 @@
-/*
-    Comment-A: 
-    rem for left-right, for consistent alignment.
-    em for top/bottom, so the spacing is relative to font-size  
-*/
 :root {
 /*===== 
     #Color #Palette 
@@ -62,6 +57,8 @@
 
 /*===== 
     #Spacing #Text #Size
+    rem for left-right, for consistent alignment.
+    em for top/bottom, so the spacing is relative to font-size  
 =====*/
     --bigSpacingHorizontal: 1.618rem;
     --baseSpacingHorizontal: .618rem;
@@ -71,7 +68,7 @@
 
 
 /*===== 
-    #Font #FontFamilies #Typeface #Code  #Heading #Paragraphs ===
+    #Font #FontFamilies #Typeface #Code #Heading #Paragraphs ===
     base is meant to be what's applied to the majority of body copy
     title could also be called "headline", but would be  w/ other vars
 =====*/

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -430,10 +430,6 @@ samp {
     border-left: var(--smallQuoteBorder);
 }
 
-data {
-    padding: 0 10px;
-}
-
 pre {
     font-size: var(--smallerTextSize);
     line-height: var(--smallLineHeight);

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -58,6 +58,16 @@
     --smallestTitleSize: var(--bigTextSize);
 
 /*===== 
+    #Spacing #Text #Size
+=====*/
+    --bigSpacingHorizontal: 1.618rem;
+    --baseSpacingHorizontal: .618rem;
+
+    --bigSpacingVertical: 1.618em;
+    --baseSpacingVertical: .618em;
+
+
+/*===== 
     #Font #FontFamilies #Typeface #Code  #Heading #Paragraphs ===
     base is meant to be what's applied to the majority of body copy
     title could also be called "headline", but would be  w/ other vars
@@ -91,7 +101,7 @@ ol,
 dl,
 pre {
     line-height: var(--baseLineHeight);
-    margin: 0 .618rem 0 .618rem; /* Comment-A */
+    margin: 0 var(--baseSpacingHorizontal);
 }
 
 
@@ -143,14 +153,14 @@ h6 {
 ul,
 ol,
 dl {
-    padding: .618em .618rem; /* Comment-A */
+    padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
 }
 
 li {
     text-indent: -.9em;
     line-height: var(--baseLineHeight);
     padding: 0;
-    margin: 0 0 0 .618rem;
+    margin: 0 0 0 var(--baseSpacingHorizontal);
 }
 
 li {
@@ -163,7 +173,7 @@ dt {
 
 dd {
     margin: 0;
-    padding: 0 .618rem 0 .618rem;
+    padding: 0 var(--baseSpacingHorizontal);
 }
 
 
@@ -175,7 +185,7 @@ hr {
     color: var(--colorNeutral);
     border-width: .0625em;
     border-style: solid;
-    margin: 1.618em .618rem;
+    margin: var(--bigSpacingVertical) var(--baseSpacingHorizontal);
 }
 
 p,
@@ -185,7 +195,7 @@ blockquote {
 
 p {
     font-size: var(--baseTextSize);
-    margin-bottom: .618em;
+    margin-bottom: var(--baseSpacingVertical);
 }
 
 
@@ -195,8 +205,8 @@ p {
 blockquote {
     background: rgba(165, 165, 165, .15);
     border-left: 10px solid var(--colorNeutralLighter);
-    margin: 1.618em .618rem; /* Comment-A */
-    padding: 0.618em .618rem;
+    margin: var(--bigSpacingVertical) var(--baseSpacingHorizontal);
+    padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
     quotes: "\201C""\201D""\2018""\2019";
 }
 
@@ -356,7 +366,7 @@ data {
 pre {
     font-size: var(--smallerTextSize);
     line-height: var(--smallLineHeight);
-    padding: .618em .618rem;
+    padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
     border: 1px solid var(--baseInlineBorderColor);
     border-radius: 2px;
     overflow: scroll;
@@ -472,7 +482,7 @@ th, td {
     text-align: left;
     vertical-align: middle;
     line-height: var(--smallLineHeight);
-    padding: .4em .618rem;
+    padding: .4em var(--baseSpacingHorizontal);
 }
 
 th {

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -250,8 +250,8 @@ blockquote::before {
 em,
 i,
 cite {
+    font-style: var(--alternateFontVoice);
 }
-font-style: var(--alternateFontVoice);
 
 strong,
 b {
@@ -497,8 +497,8 @@ table {
 caption {
     font-size:  var(--baseTextSize);
     text-transform: capitalize;
+    font-style: var(--alternateFontVoice);
 }
-font-style: var(--alternateFontVoice);
 
 th, td {
     text-align: left;

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -86,7 +86,18 @@
 =====*/
     --lightestFontWeight: 100;
     --baseFontWeight: 400;
-    --heaviestFontWeight: 700; 
+    --heaviestFontWeight: 700;
+
+/*===== 
+    #font #style
+    Oblique will use the existing font and put the glyphs at an angle
+    Alternate will look for a font labelled with an italic face
+    If the font doesn't have a
+=====*/
+
+    --fontVoiceAlternate: italic;
+    --fontVoiceShifted: oblique 15deg;
+    --fontVoiceNormal: normal;
 }
 
 html {
@@ -239,7 +250,7 @@ blockquote::before {
 em,
 i,
 cite {
-    font-style: italic;
+    font-style: var(--fontVoiceAlternate);
 }
 
 strong,
@@ -253,8 +264,7 @@ cite {
 }
 
 u {
-    text-decoration: none;
-    border-bottom: 1px dotted red;
+    text-decoration: dotted underline red 1px;
 }
 
 small,
@@ -287,7 +297,7 @@ ins {
 s,
 strike,
 del {
-    text-decoration: strikethrough;
+    text-decoration: line-through;
 }
 
 ins,
@@ -325,7 +335,7 @@ mark::selection {
 /* dfn and dt both do the same thing: denote a term to be defined */
 dfn,
 dt {
-    font-style: oblique;
+    font-style: var(--fontVoiceShifted);
     font-weight: var(--heaviestFontWeight);
     text-transform: capitalize;
 }
@@ -364,7 +374,7 @@ data {
 
 var,
 data {
-    font-style: italic;
+    font-style: var(--fontVoiceAlternate);
 }
 
 samp {
@@ -487,7 +497,7 @@ table {
 caption {
     font-size:  var(--baseTextSize);
     text-transform: capitalize;
-    font-style: italic;
+    font-style: var(--fontVoiceAlternate);
 }
 
 th, td {

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -168,7 +168,7 @@ li {
 }
 
 dt {
-    text-indent: -.618rem;
+    text-indent: calc(-1 * var(--baseSpacingHorizontal));
 }
 
 dd {

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -92,12 +92,12 @@
     #font #style
     Oblique will use the existing font and put the glyphs at an angle
     Alternate will look for a font labelled with an italic face
-    If the font doesn't have a
+    If the browser doesn't have a labelled italic font, it synthesizes oblique
 =====*/
 
-    --fontVoiceAlternate: italic;
-    --fontVoiceShifted: oblique 15deg;
-    --fontVoiceNormal: normal;
+    --shiftedFontVoice: oblique 15deg;
+    --baseFontVoice: normal;
+    --alternateFontVoice: italic;
 }
 
 html {
@@ -250,8 +250,8 @@ blockquote::before {
 em,
 i,
 cite {
-    font-style: var(--fontVoiceAlternate);
 }
+font-style: var(--alternateFontVoice);
 
 strong,
 b {
@@ -335,7 +335,7 @@ mark::selection {
 /* dfn and dt both do the same thing: denote a term to be defined */
 dfn,
 dt {
-    font-style: var(--fontVoiceShifted);
+    font-style: var(--shiftedFontVoice);
     font-weight: var(--heaviestFontWeight);
     text-transform: capitalize;
 }
@@ -374,8 +374,8 @@ data {
 
 var,
 data {
-    font-style: var(--fontVoiceAlternate);
 }
+font-style: var(--alternateFontVoice);
 
 samp {
     border-left: 5px solid var(--baseInlineBorderColor);
@@ -497,8 +497,8 @@ table {
 caption {
     font-size:  var(--baseTextSize);
     text-transform: capitalize;
-    font-style: var(--fontVoiceAlternate);
 }
+font-style: var(--alternateFontVoice);
 
 th, td {
     text-align: left;

--- a/src/baseline.css
+++ b/src/baseline.css
@@ -101,6 +101,11 @@
     --alternateFontVoice: italic;
 
 /*===== 
+    #font #quotes
+=====*/
+    --baseTextQuotes: "\201C""\201D""\2018""\2019"; /*Primary open, primary close, secondary open, secondary close*/
+
+/*===== 
     #font #text #interactions
     Interactions could/should include
         idle: not being used, but an indicator that it can be
@@ -233,6 +238,15 @@ p {
     margin-bottom: var(--baseSpacingVertical);
 }
 
+blockquote,
+q {
+    quotes: var(--baseTextQuotes);
+}
+
+blockquote::before,
+q::before {
+    content: open-quote;
+}
 
 /* Credit where it's due:
     https://css-tricks.com/snippets/css/simple-and-nice-blockquote-styling/
@@ -242,18 +256,23 @@ blockquote {
     border-left: 10px solid var(--colorNeutralLighter);
     margin: var(--bigSpacingVertical) var(--baseSpacingHorizontal);
     padding: var(--baseSpacingVertical) var(--baseSpacingHorizontal);
-    quotes: "\201C""\201D""\2018""\2019";
 }
 
 blockquote::before {
     color: var(--colorNeutralLight);
-    content: open-quote;
     font-size: 4em;
     line-height: 0.1em;
     margin-right: 0.25em;
     vertical-align: -0.4em;
 }
 
+blockquote::after {
+    content: no-close-quote;
+}
+
+q::after {
+    content: close-quote;
+}
 
 /*=====
   #Content-Flow


### PR DESCRIPTION
The purpose of this is to make the typography baseline more amiable to being used in Web Components -- which don't inherit styles, only CSS Variables. 

so this is meant to add variables for some of the following:

* spacing (margin and padding)
* background colors and borders
* font weights
* font styles
* Quote styles